### PR TITLE
Add VIOS automation scripts and smoke tests

### DIFF
--- a/scripts/create_npiv.sh
+++ b/scripts/create_npiv.sh
@@ -1,31 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DRY_RUN=1
-if [ "${APPLY:-0}" -eq 1 ]; then DRY_RUN=0; fi
+SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
+. "$SCRIPT_DIR/../lib/common.sh"
 
 usage(){ echo "Usage: $0 <LPAR> [--slot N] [--vios VIOSx] [--dry-run]" >&2; exit 1; }
 
-LPAR=""; SLOT="auto"; VIOS="${VIOS1:-}";
+parse_flags "$@"
+set -- "${ARGS[@]}"
+
+LPAR=""; SLOT="auto"; VIOS="${VIOS1:-}"
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --dry-run) DRY_RUN=1; shift;;
     --slot) SLOT="$2"; shift 2;;
     --vios) VIOS="$2"; shift 2;;
-    --help) usage;;
-    *) LPAR="$1"; shift;;
+    *) [ -z "$LPAR" ] && LPAR="$1" || usage; shift;;
   esac
 done
 [ -n "$LPAR" ] || usage
 
-SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
-. "$SCRIPT_DIR/../lib/common.sh"
-
 require_env MS
 [ -n "$VIOS" ] || { log err "VIOS not set"; exit 1; }
 
-H "chhwres -m $MS -r virtualio --rsubtype fc -o a -p $VIOS -s $SLOT -a adapter_type=server,remote_lpar_name=$LPAR"
-H "chhwres -m $MS -r virtualio --rsubtype fc -o a -p $LPAR -s $SLOT -a adapter_type=client,remote_lpar_name=$VIOS"
+log info "Creating NPIV pair on $VIOS slot $SLOT for $LPAR"
+H "chhwres -m \"$MS\" -r virtualio --rsubtype fc -o a -p \"$VIOS\" -s \"$SLOT\" -a adapter_type=server,remote_lpar_name=$LPAR"
+H "chhwres -m \"$MS\" -r virtualio --rsubtype fc -o a -p \"$LPAR\" -s \"$SLOT\" -a adapter_type=client,remote_lpar_name=$VIOS"
 H "lsmap -npiv"
 
 echo "WWPNS=WWPN1,WWPN2"

--- a/scripts/create_sea.sh
+++ b/scripts/create_sea.sh
@@ -1,25 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DRY_RUN=1
-if [ "${APPLY:-0}" -eq 1 ]; then DRY_RUN=0; fi
-
-usage(){ echo "Usage: $0 [--dry-run]" >&2; exit 1; }
-
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --dry-run) DRY_RUN=1; shift;;
-    --help) usage;;
-    *) usage;;
-  esac
-done
-
 SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
 . "$SCRIPT_DIR/../lib/common.sh"
 
+usage(){ echo "Usage: $0 [--dry-run]" >&2; exit 1; }
+
+parse_flags "$@"
+set -- "${ARGS[@]}"
+[ "$#" -eq 0 ] || usage
+
 require_env MS VIOS1 BACKING_ETH TRUNK_ADAPTER VSWITCH SEA_VLAN
 
-H "mkvdev -sea $BACKING_ETH -vadapter $TRUNK_ADAPTER -default -defaultid $SEA_VLAN -attr ha_mode=auto virt_adapters=$TRUNK_ADAPTER vswitch=$VSWITCH"
+log info "Creating SEA on $VIOS1"
+H "mkvdev -sea \"$BACKING_ETH\" -vadapter \"$TRUNK_ADAPTER\" -default -defaultid \"$SEA_VLAN\" -attr ha_mode=auto virt_adapters=\"$TRUNK_ADAPTER\" vswitch=\"$VSWITCH\""
 H "entstat -d sea0"
 
 echo "SEA=sea0"

--- a/scripts/create_vscsi.sh
+++ b/scripts/create_vscsi.sh
@@ -1,35 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DRY_RUN=1
-if [ "${APPLY:-0}" -eq 1 ]; then
-  DRY_RUN=0
-fi
+SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
+. "$SCRIPT_DIR/../lib/common.sh"
 
 usage() { echo "Usage: $0 <LPAR> [--dry-run]" >&2; exit 1; }
 
-LPAR=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --dry-run) DRY_RUN=1 ; shift ;;
-    --help) usage ;;
-    *) LPAR="$1" ; shift ; break ;;
-  esac
-done
+parse_flags "$@"
+set -- "${ARGS[@]}"
 
-[ -n "$LPAR" ] || usage
-
-SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
-. "$SCRIPT_DIR/../lib/common.sh"
+[ "$#" -eq 1 ] || usage
+LPAR="$1"
 
 require_env MS VIOS1
 
 if ! ensure_once "vscsi_$LPAR"; then
+  log info "vSCSI pair for $LPAR already exists"
   echo "VHOST=existing"
   exit 0
 fi
 
-H "mkvdev -m $MS -r vscsi -s -p $VIOS1 -a adapter_type=server,remote_lpar_name=$LPAR,remote_slot_num=auto"
-H "lsmap -all -type vhost | grep -i $LPAR"
+H "mkvdev -m \"$MS\" -r vscsi -s -p \"$VIOS1\" -a adapter_type=server,remote_lpar_name=$LPAR,remote_slot_num=auto"
+H "lsmap -all -type vhost | grep -i \"$LPAR\""
 
 echo "VHOST=vhost?"

--- a/scripts/map_scsi.sh
+++ b/scripts/map_scsi.sh
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DRY_RUN=1
-if [ "${APPLY:-0}" -eq 1 ]; then DRY_RUN=0; fi
-
-usage(){ echo "Usage: $0 <LPAR> <hdiskN> [--dry-run]" >&2; exit 1; }
-
-LPAR=""; DISK=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --dry-run) DRY_RUN=1; shift;;
-    --help) usage;;
-    *) if [ -z "$LPAR" ]; then LPAR="$1"; elif [ -z "$DISK" ]; then DISK="$1"; else break; fi; shift;;
-  esac
-done
-[ -n "$LPAR" ] && [ -n "$DISK" ] || usage
-
 SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
 . "$SCRIPT_DIR/../lib/common.sh"
 
+usage(){ echo "Usage: $0 <LPAR> <hdiskN> [--dry-run]" >&2; exit 1; }
+
+parse_flags "$@"
+set -- "${ARGS[@]}"
+
+[ "$#" -ge 2 ] || usage
+LPAR="$1"; DISK="$2"; shift 2
+
 require_env MS VIOS1
 
-VHOST="vhost?"
-H "lshwres -m $MS -r virtualio --rsubtype scsi -F phys_loc,client_lpar_name | grep $LPAR"
-H "mkvdev -m $MS -vdev $DISK -vadapter $VHOST"
-H "lsmap -vadapter $VHOST"
+VHOST_CMD="lshwres -m \"$MS\" -r virtualio --rsubtype scsi -F phys_loc,client_lpar_name | grep ',"$LPAR"$' | cut -d, -f1"
+if [ "$DRY_RUN" -eq 1 ]; then
+  H "$VHOST_CMD"
+  VHOST="vhost?"
+else
+  VHOST=$(H "$VHOST_CMD")
+fi
+
+log info "Mapping $DISK to $LPAR via $VHOST"
+H "mkvdev -m \"$MS\" -vdev \"$DISK\" -vadapter \"$VHOST\""
+H "lsmap -vadapter \"$VHOST\""
 
 echo "MAPPED=$LPAR:$DISK"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,19 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DRY_RUN=1
-if [ "${APPLY:-0}" -eq 1 ]; then DRY_RUN=0; fi
-
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --dry-run) DRY_RUN=1; shift;;
-    --help) echo "Usage: $0 [--dry-run]" >&2; exit 0;;
-    *) shift;;
-  esac
-done
-
 SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
 . "$SCRIPT_DIR/../lib/common.sh"
+
+usage(){ echo "Usage: $0 [--dry-run]" >&2; exit 0; }
+
+parse_flags "$@"
+set -- "${ARGS[@]}"
+[ "$#" -eq 0 ] || usage
 
 require_env MS VIOS1
 


### PR DESCRIPTION
## Summary
- centralize flag parsing and logging helpers
- harden SSH command quoting and update scripts to use shared parser
- resolve vhost lookup in disk mapping script

## Testing
- `tests/smoke.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a08f652d288323ab24eb5d03845cb7

## Summary by Sourcery

Add a shared common.sh library for environment loading, logging, flag parsing, and command execution, and provide a set of VIOS automation scripts (vSCSI, NPIV, SCSI mapping, SEA, verify) with accompanying smoke tests and updated documentation.

New Features:
- Add common library for flag parsing, logging, and SSH/VIOS command abstractions
- Introduce automation scripts for vSCSI, NPIV, SCSI mapping, SEA creation, and verification
- Add smoke test suite to run all scripts in dry-run mode

Bug Fixes:
- Harden SSH command quoting and fix vhost lookup in the disk mapping script

Documentation:
- Update README with prerequisites, quickstart guide, safety notes, and known limitations