### PR TITLE
Improve portability and environment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repeatable operations with clear dry‑run support.
 |------|-------------|
 | `lib/` | Shared shell utilities (environment loading, logging, SSH helpers) |
 | `scripts/` | Operational logic for vSCSI, NPIV, SEA and more |
-| `maps/` | User supplied mapping files consumed by scripts |
+| `maps/` | User-supplied mapping files consumed by scripts |
 | `tests/` | Automated tests using [bats-core](https://bats-core.readthedocs.io) |
 | `extensions/` | Optional plugin hooks auto-discovered by `vios-auto.sh` |
 
@@ -48,7 +48,7 @@ usage details.
 
 - All scripts execute with `set -euo pipefail`.
 - Commands default to dry‑run mode; nothing changes until explicitly confirmed.
-- Idempotency markers in `/var/tmp/vios-autoconfig-*` prevent repeated work
+- Idempotency markers in `${TMPDIR:-/var/tmp}/vios-autoconfig-*` prevent repeated work
   unless `--force` is supplied.
 - Logging uses INFO/WARN/ERROR levels and masks credentials.
 

--- a/vios-auto.sh
+++ b/vios-auto.sh
@@ -44,16 +44,18 @@ if [ "${1:-}" = "--help" ]; then
   exit 0
 fi
 
-load_env
-
 case "$cmd" in
   create-vscsi)
+    load_env MS VIOS1
     "$SCRIPT_DIR/scripts/create-vscsi.sh" "$@" ;;
   create-npiv)
+    load_env
     "$SCRIPT_DIR/scripts/create-npiv.sh" "$@" ;;
   create-sea)
+    load_env
     "$SCRIPT_DIR/scripts/create-sea.sh" "$@" ;;
   run-extension)
+    load_env
     [ "$#" -gt 0 ] || { log ERROR "Missing extension name"; exit 1; }
     "$SCRIPT_DIR/extensions/$1.sh" "${@:2}" ;;
   *)


### PR DESCRIPTION
## Summary
- make `load_env` portable, prompt for required variables, and validate permissions without GNU stat
- expand secret masking and hash marker names in a configurable temporary directory
- document marker location, fix hyphenation, and load subcommand-specific env vars

## Testing
- `bats tests` *(fails: command not found)*
- `apt-get install -y shellcheck` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c053b5188323b1138ddee4678cf2