### PR TITLE
Fix dynamic variable assignment in load_env

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -20,15 +20,15 @@ load_env() {
   fi
   for var in "${vars[@]}"; do
     if [ -z "${!var:-}" ]; then
-      local var_uc
+      local var_uc val
       var_uc=$(printf '%s' "$var" | tr '[:lower:]' '[:upper:]')
       case $var_uc in
         *PASSWORD*|*TOKEN*|*SECRET*)
-          read -r -s -p "$var: " "$var"; echo ;;
+          read -r -s -p "$var: " val; echo ;;
         *)
-          read -r -p "$var: " "$var" ;;
+          read -r -p "$var: " val ;;
       esac
-      export "$var"
+      export "$var=$val"
     fi
   done
   require_env "${vars[@]}"


### PR DESCRIPTION
## Summary
- ensure load_env assigns user input to the intended variable by capturing into a temporary variable before export

## Testing
- `bash tests/smoke.sh` *(fails: scripts missing/parse_flags not found)*
- `bats tests/test-env-loading.bats` *(could not run: bats not installed; apt-get update 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c77c56508323badcc1d2f3f7be45