### PR TITLE
Refactor env input reading

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -20,14 +20,13 @@ load_env() {
   fi
   for var in "${vars[@]}"; do
     if [ -z "${!var:-}" ]; then
-      local var_uc val
+      local var_uc val is_secret
       var_uc=$(printf '%s' "$var" | tr '[:lower:]' '[:upper:]')
       case $var_uc in
-        *PASSWORD*|*TOKEN*|*SECRET*)
-          read -r -s -p "$var: " val; echo ;;
-        *)
-          read -r -p "$var: " val ;;
+        *PASSWORD*|*TOKEN*|*SECRET*) is_secret=1 ;;
       esac
+      read -r ${is_secret:+-s} -p "$var: " val
+      echo
       export "$var=$val"
     fi
   done


### PR DESCRIPTION
## Summary
- unify environment variable prompting using conditional `-s`
- echo newline after all input reads

## Testing
- `./tests/smoke.sh` *(fails: scripts missing or parse_flags not found)*
- `bats tests/test-env-loading.bats` *(fails: command not found; `apt-get update` fails with 403)*
- `shellcheck lib/common.sh` *(fails: command not found; `apt-get update` fails with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ce204e248323a48bab7f64250185

## Summary by Sourcery

Enhancements:
- Refactor load_env to unify environment variable prompting into a single read invocation with a conditional -s flag for secret variables and always echo a newline after input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment setup prompts now automatically hide input for secret-like variables (names containing PASSWORD, TOKEN, or SECRET), improving privacy during load_env.
  * All variables use a consistent prompt with a clean newline after entry for better readability. Non-secret variables behave as before, while secrets are read silently to avoid exposing values on screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->