### PR TITLE
chore: trim version string and pin release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Verify tag
         run: |
           if [ -f VERSION ]; then
-            v=$(cat VERSION)
+            v=$(cat VERSION | awk '{$1=$1};1')
             if [ "v$v" != "${GITHUB_REF_NAME}" ]; then
               echo "Tag does not match VERSION file" >&2
               exit 1
@@ -32,6 +32,6 @@ jobs:
           name: dist
           path: dist/*
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@d8199f1870e7d2834e97e1f38da813e1ea977473
         with:
           files: dist/*


### PR DESCRIPTION
## Summary
- trim whitespace from VERSION before tag comparison
- pin softprops/action-gh-release to a commit SHA

## Testing
- `pre-commit run --files .github/workflows/release.yml` *(fails: command not found)*
- `make test` *(fails: bats: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d64490fc832384d84cd8ebf81c41

## Summary by Sourcery

Strengthen the release workflow by trimming whitespace from VERSION prior to tag validation and pinning the gh-release action to a fixed commit SHA

Bug Fixes:
- Trim whitespace from the VERSION file before comparing it to the Git tag to prevent mismatches

CI:
- Pin softprops/action-gh-release to a specific commit SHA for deterministic workflow execution