### PR TITLE
Refactor flag parsing and harden env handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4b41b3237a197458ad2de298c59bfec9ef2545e
       - name: ShellCheck
-        uses: ludeeus/action-shellcheck@v2
+        uses: ludeeus/action-shellcheck@b6236dad3b09e5b564e30f68720259e86cdc84e8
         with:
           scandir: './'
         env:
@@ -22,8 +22,8 @@ jobs:
   shfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ktomk/setup-shfmt@v10
+      - uses: actions/checkout@b4b41b3237a197458ad2de298c59bfec9ef2545e
+      - uses: ktomk/setup-shfmt@f7ed5480a219c2f4780e8851c42e9906efeedd28
         with: { shfmt: v3.7.0 }
       - name: Check formatting
         run: shfmt -d -i 2 -ci -sr .
@@ -31,18 +31,18 @@ jobs:
   bats:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4b41b3237a197458ad2de298c59bfec9ef2545e
       - name: Setup Bats
-        uses: bats-core/bats-action@2.0.0
+        uses: bats-core/bats-action@5df2103881a98389f43a4ce674563d6ba81ae3ae
       - name: Run tests
         run: bats -r tests
 
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4b41b3237a197458ad2de298c59bfec9ef2545e
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@cf6e9e78e2b7a003444b249bca7ff2809916900b
         env:
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
           GITLEAKS_ENABLE_SUMMARY: "true"
@@ -50,9 +50,9 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4b41b3237a197458ad2de298c59bfec9ef2545e
       - name: Lint GitHub Actions
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@c4dfb4228e1e8b4d5900b0e564b9b0d0a26d4684
         with:
           actionlint_flags: -color
 

--- a/scripts/create_npiv.sh
+++ b/scripts/create_npiv.sh
@@ -16,18 +16,7 @@ EOF
 MS=""; VIOS=""; LPAR=""; SLOT=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --ms) MS="$2"; shift 2 ;;
-    --vios) VIOS="$2"; shift 2 ;;
-    --lpar) LPAR="$2"; shift 2 ;;
-    --slot) SLOT="$2"; shift 2 ;;
-    --dry-run) DRY_RUN=1; shift ;;
-    --apply) APPLY=1; shift ;;
-    -h|--help) usage; exit 0 ;;
-    *) die "Unknown arg: $1" ;;
-  esac
-done
+parse_flags "$@"
 
 [[ -n "${MS}" && -n "${VIOS}" && -n "${LPAR}" && -n "${SLOT}" ]] || { usage; exit 2; }
 
@@ -39,20 +28,7 @@ done
 common_init
 confirm_apply
 
-run_hmc() {
-  require_cmd ssh
-  local cmd="$*"
-  [[ "${cmd}" != *$'\n'* && "${cmd}" != *";"* && "${cmd}" != *$'\r'* ]] || die "Refusing unsafe command"
-  local ssh_cmd=(ssh -i "${HMC_SSH_KEY}" "${DEFAULT_SSH_OPTS[@]}" "${HMC_USER}@${HMC_HOST}" -- "${cmd}")
-  if [[ "${DRY_RUN}" == "1" || "${APPLY}" != "1" ]]; then
-    log INFO "[dry-run] ${ssh_cmd[*]}"
-    return 0
-  fi
-  log INFO "HMC: ${cmd}"
-  "${ssh_cmd[@]}" 2> >(tee -a "${LOG_DIR}/hmc.err" >&2) | tee -a "${LOG_DIR}/hmc.out"
-}
-
-with_lock "npiv-${LPAR}-${SLOT}" bash -c '
+with_lock "npiv-${MS}-${LPAR}-${SLOT}" bash -c '
   run_hmc "chhwres -m '"${MS}"' -r virtualio --rsubtype fc -o a -p '"${VIOS}"' -s '"${SLOT}"' -a adapter_type=server,remote_lpar_name='"${LPAR}"'"
   run_hmc "chhwres -m '"${MS}"' -r virtualio --rsubtype fc -o a -p '"${LPAR}"' -s '"${SLOT}"' -a adapter_type=client,remote_lpar_name='"${VIOS}"'"
   run_hmc_vios '"${VIOS}"' "ioscli lsmap -all -npiv"

--- a/scripts/create_sea.sh
+++ b/scripts/create_sea.sh
@@ -16,19 +16,7 @@ EOF
 VIOS=""; BACKING=""; TRUNK=""; VSWITCH=""; VLAN=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --vios) VIOS="$2"; shift 2 ;;
-    --backing) BACKING="$2"; shift 2 ;;
-    --trunk) TRUNK="$2"; shift 2 ;;
-    --vswitch) VSWITCH="$2"; shift 2 ;;
-    --vlan) VLAN="$2"; shift 2 ;;
-    --dry-run) DRY_RUN=1; shift ;;
-    --apply) APPLY=1; shift ;;
-    -h|--help) usage; exit 0 ;;
-    *) die "Unknown arg: $1" ;;
-  esac
-done
+parse_flags "$@"
 
 [[ -n "${VIOS}" && -n "${BACKING}" && -n "${TRUNK}" && -n "${VSWITCH}" && -n "${VLAN}" ]] || { usage; exit 2; }
 
@@ -40,7 +28,7 @@ done
 common_init
 confirm_apply
 
-with_lock "sea-${VIOS}" bash -c '
+with_lock "sea-${VIOS}-${VSWITCH}-${VLAN}" bash -c '
   run_hmc_vios "'"${VIOS}"'" "ioscli mkvdev -sea '"${BACKING}"' -vadapter '"${TRUNK}"' -default -defaultid '"${VLAN}"' -attr ha_mode=auto virt_adapters='"${TRUNK}"' vswitch='"${VSWITCH}"'"
   run_hmc_vios "'"${VIOS}"'" "ioscli entstat -d sea0"
 '

--- a/scripts/create_vscsi.sh
+++ b/scripts/create_vscsi.sh
@@ -13,44 +13,31 @@ Env: DRY_RUN=1 or APPLY=1; ./.env supplies HMC_* variables
 EOF
 }
 
-MS=""; VIOS=""; LPAR=""; S_SLOT=""; C_SLOT=""
+MS=""; VIOS=""; LPAR=""; SERVER_SLOT=""; CLIENT_SLOT=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
-# Parse flags
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --ms) MS="$2"; shift 2 ;;
-    --vios) VIOS="$2"; shift 2 ;;
-    --lpar) LPAR="$2"; shift 2 ;;
-    --server-slot) S_SLOT="$2"; shift 2 ;;
-    --client-slot) C_SLOT="$2"; shift 2 ;;
-    --dry-run) DRY_RUN=1; shift ;;
-    --apply) APPLY=1; shift ;;
-    -h|--help) usage; exit 0 ;;
-    *) die "Unknown arg: $1" ;;
-  esac
-done
+parse_flags "$@"
 
-[[ -n "${MS}" && -n "${VIOS}" && -n "${LPAR}" && -n "${S_SLOT}" && -n "${C_SLOT}" ]] || { usage; exit 2; }
+[[ -n "${MS}" && -n "${VIOS}" && -n "${LPAR}" && -n "${SERVER_SLOT}" && -n "${CLIENT_SLOT}" ]] || { usage; exit 2; }
 
 # Validate tokens
 for x in "${MS}" "${VIOS}" "${LPAR}"; do
   [[ "${x}" =~ ^[A-Za-z0-9._:-]+$ ]] || die "Invalid name: ${x}"
 done
-[[ "${S_SLOT}" =~ ^[0-9]+$ && "${C_SLOT}" =~ ^[0-9]+$ ]] || die "Slots must be integers"
+[[ "${SERVER_SLOT}" =~ ^[0-9]+$ && "${CLIENT_SLOT}" =~ ^[0-9]+$ ]] || die "Slots must be integers"
 
 # Init + optional confirmation
 common_init
 confirm_apply
 
 # Prevent duplicate by lock on LPAR mapping
-with_lock "vscsi-${LPAR}-${S_SLOT}-${C_SLOT}" bash -c '
+with_lock "vscsi-${MS}-${LPAR}-${SERVER_SLOT}-${CLIENT_SLOT}" bash -c '
   # 1) Ensure server vhost exists on VIOS
-  run_hmc_vios "'"${VIOS}"'" "ioscli mkvdev -r server -s vscsi -fbo -dev vhost'"${S_SLOT}"'"" || true
+  run_hmc_vios "'"${VIOS}"'" "ioscli mkvdev -r server -s vscsi -fbo -dev vhost'"${SERVER_SLOT}"'"" || true
   # 2) Map to client
-  run_hmc_vios "'"${VIOS}"'" "ioscli mkvscsi -vadapter vhost'"${S_SLOT}"' -client '"${LPAR}"' -clslot '"${C_SLOT}"'"
+  run_hmc_vios "'"${VIOS}"'" "ioscli mkvscsi -vadapter vhost'"${SERVER_SLOT}"' -client '"${LPAR}"' -clslot '"${CLIENT_SLOT}"'"
   # 3) Verify
   run_hmc_vios "'"${VIOS}"'" "ioscli lsmap -all -fmt :"
 '
-log INFO "vSCSI mapping ensured: ${VIOS}:vhost${S_SLOT} -> ${LPAR}:${C_SLOT}"
+log INFO "vSCSI mapping ensured: ${VIOS}:vhost${SERVER_SLOT} -> ${LPAR}:${CLIENT_SLOT}"
 

--- a/scripts/map_scsi.sh
+++ b/scripts/map_scsi.sh
@@ -16,18 +16,7 @@ EOF
 VIOS=""; LPAR=""; VHOST=""; DISK=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --vios) VIOS="$2"; shift 2 ;;
-    --lpar) LPAR="$2"; shift 2 ;;
-    --vhost) VHOST="$2"; shift 2 ;;
-    --disk) DISK="$2"; shift 2 ;;
-    --dry-run) DRY_RUN=1; shift ;;
-    --apply) APPLY=1; shift ;;
-    -h|--help) usage; exit 0 ;;
-    *) die "Unknown arg: $1" ;;
-  esac
-done
+parse_flags "$@"
 
 [[ -n "${VIOS}" && -n "${LPAR}" && -n "${VHOST}" && -n "${DISK}" ]] || { usage; exit 2; }
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -16,15 +16,7 @@ EOF
 VIOS=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --vios) VIOS="$2"; shift 2 ;;
-    --dry-run) DRY_RUN=1; shift ;;
-    --apply) APPLY=1; shift ;;
-    -h|--help) usage; exit 0 ;;
-    *) die "Unknown arg: $1" ;;
-  esac
-done
+parse_flags "$@"
 
 [[ -n "${VIOS}" ]] || { usage; exit 2; }
 [[ "${VIOS}" =~ ^[A-Za-z0-9._:-]+$ ]] || die "Invalid VIOS: ${VIOS}"

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -6,7 +6,7 @@ setup() {
 }
 
 @test "lib/common.sh loads without env (missing vars) -> fails" {
-  run bash -c 'set -euo pipefail; IFS=$'"'\n\t'"'; . ./lib/common.sh; load_env /dev/null'
+  run bash -c 'set -euo pipefail; IFS=$'"'\n\t'"'; tmp=$(mktemp); chmod 600 "$tmp"; . ./lib/common.sh; load_env "$tmp"'
   [ "$status" -ne 0 ]
   [[ "$output" == *"HMC_HOST is required"* ]]
 }


### PR DESCRIPTION
## Summary
- centralize CLI flag parsing and raw HMC execution in common helpers
- enforce 600 permissions when loading `.env` and warn on SSH key chmod errors
- expand redaction, lock handling, and workflow security pins

## Testing
- `make lint` *(fails: shellcheck: command not found)*
- `apt-get update` *(fails: 403 Forbidden when updating package lists)*
- `make test` *(fails: bats: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fd9e736c8323b2aa2b70ff9221fc

## Summary by Sourcery

Refactor and harden common shell utilities by centralizing flag parsing and raw HMC execution, enforcing stricter environment file permissions, improving logging redaction and lock handling, standardizing script interfaces, and pinning CI workflow actions

New Features:
- Add parse_flags helper to centralize CLI flag parsing across scripts
- Add run_hmc helper to execute raw HMC commands securely over SSH

Enhancements:
- Harden load_env to enforce 600 permissions on .env and warn on SSH key chmod failures
- Enhance log redaction to catch standalone sensitive tokens and unify formatting
- Refactor with_lock to use dynamic file descriptors and close locks properly
- Refactor scripts to use the new parse_flags helper, update lock keys, and standardize variable names
- Pin specific commit SHAs for GitHub Actions in CI workflows for reproducible builds

Tests:
- Update common.sh tests to set and validate 600 permissions on temporary env files