### PR TITLE
Improve portability and security of helpers

### DIFF
--- a/scripts/create_npiv.sh
+++ b/scripts/create_npiv.sh
@@ -13,10 +13,14 @@ Env: DRY_RUN=1 or APPLY=1; ./.env supplies HMC_* variables
 EOF
 }
 
-MS=""; VIOS=""; LPAR=""; SLOT=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
 parse_flags "$@"
+
+MS="${FLAG_MS:-}"
+VIOS="${FLAG_VIOS:-}"
+LPAR="${FLAG_LPAR:-}"
+SLOT="${FLAG_SLOT:-}"
 
 [[ -n "${MS}" && -n "${VIOS}" && -n "${LPAR}" && -n "${SLOT}" ]] || { usage; exit 2; }
 
@@ -29,8 +33,8 @@ common_init
 confirm_apply
 
 with_lock "npiv-${MS}-${LPAR}-${SLOT}" bash -c '
-  run_hmc "chhwres -m '"${MS}"' -r virtualio --rsubtype fc -o a -p '"${VIOS}"' -s '"${SLOT}"' -a adapter_type=server,remote_lpar_name='"${LPAR}"'"
-  run_hmc "chhwres -m '"${MS}"' -r virtualio --rsubtype fc -o a -p '"${LPAR}"' -s '"${SLOT}"' -a adapter_type=client,remote_lpar_name='"${VIOS}"'"
+  run_hmc chhwres -m '"${MS}"' -r virtualio --rsubtype fc -o a -p '"${VIOS}"' -s '"${SLOT}"' -a adapter_type=server,remote_lpar_name='"${LPAR}"''
+  run_hmc chhwres -m '"${MS}"' -r virtualio --rsubtype fc -o a -p '"${LPAR}"' -s '"${SLOT}"' -a adapter_type=client,remote_lpar_name='"${VIOS}"''
   run_hmc_vios '"${VIOS}"' "ioscli lsmap -all -npiv"
 '
 log INFO "NPIV mapping ensured: ${VIOS}<->${LPAR} slot ${SLOT}"

--- a/scripts/create_sea.sh
+++ b/scripts/create_sea.sh
@@ -13,10 +13,15 @@ Env: DRY_RUN=1 or APPLY=1; ./.env supplies HMC_* variables
 EOF
 }
 
-VIOS=""; BACKING=""; TRUNK=""; VSWITCH=""; VLAN=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
 parse_flags "$@"
+
+VIOS="${FLAG_VIOS:-}"
+BACKING="${FLAG_BACKING:-}"
+TRUNK="${FLAG_TRUNK:-}"
+VSWITCH="${FLAG_VSWITCH:-}"
+VLAN="${FLAG_VLAN:-}"
 
 [[ -n "${VIOS}" && -n "${BACKING}" && -n "${TRUNK}" && -n "${VSWITCH}" && -n "${VLAN}" ]] || { usage; exit 2; }
 

--- a/scripts/create_vscsi.sh
+++ b/scripts/create_vscsi.sh
@@ -13,10 +13,15 @@ Env: DRY_RUN=1 or APPLY=1; ./.env supplies HMC_* variables
 EOF
 }
 
-MS=""; VIOS=""; LPAR=""; SERVER_SLOT=""; CLIENT_SLOT=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
 parse_flags "$@"
+
+MS="${FLAG_MS:-}"
+VIOS="${FLAG_VIOS:-}"
+LPAR="${FLAG_LPAR:-}"
+SERVER_SLOT="${FLAG_SERVER_SLOT:-}"
+CLIENT_SLOT="${FLAG_CLIENT_SLOT:-}"
 
 [[ -n "${MS}" && -n "${VIOS}" && -n "${LPAR}" && -n "${SERVER_SLOT}" && -n "${CLIENT_SLOT}" ]] || { usage; exit 2; }
 

--- a/scripts/map_scsi.sh
+++ b/scripts/map_scsi.sh
@@ -13,10 +13,14 @@ Env: DRY_RUN=1 or APPLY=1; ./.env supplies HMC_* variables
 EOF
 }
 
-VIOS=""; LPAR=""; VHOST=""; DISK=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
 parse_flags "$@"
+
+VIOS="${FLAG_VIOS:-}"
+LPAR="${FLAG_LPAR:-}"
+VHOST="${FLAG_VHOST:-}"
+DISK="${FLAG_DISK:-}"
 
 [[ -n "${VIOS}" && -n "${LPAR}" && -n "${VHOST}" && -n "${DISK}" ]] || { usage; exit 2; }
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -13,10 +13,11 @@ Env: DRY_RUN=1 or APPLY=1; ./.env supplies HMC_* variables
 EOF
 }
 
-VIOS=""
 DRY_RUN="${DRY_RUN:-0}"; APPLY="${APPLY:-0}"
 
 parse_flags "$@"
+
+VIOS="${FLAG_VIOS:-}"
 
 [[ -n "${VIOS}" ]] || { usage; exit 2; }
 [[ "${VIOS}" =~ ^[A-Za-z0-9._:-]+$ ]] || die "Invalid VIOS: ${VIOS}"

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -17,3 +17,15 @@ setup() {
   [[ "$output" == *"[dry-run]"* ]]
 }
 
+@test "parse_flags isolates variables" {
+  run bash -lc 'set -euo pipefail; IFS=$'"'\n\t'"'; . ./lib/common.sh; parse_flags --path /tmp --foo bar; [[ "$PATH" != "/tmp" && "$FLAG_FOO" == "bar" && "$FLAG_PATH" == "/tmp" ]] && echo ok'
+  [ "$status" -eq 0 ]
+  [ "$output" = "ok" ]
+}
+
+@test "run_hmc rejects unsafe metacharacters" {
+  run bash -lc 'set -euo pipefail; IFS=$'"'\n\t'"'; tmp=$(mktemp); chmod 600 "$tmp"; HMC_HOST=h HMC_USER=u HMC_SSH_KEY="$tmp" DRY_RUN=1 APPLY=1; . ./lib/common.sh; run_hmc ls "|" wc'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Refusing unsafe command"* ]]
+}
+


### PR DESCRIPTION
## Summary
- Make load_env permission checks portable across GNU/BSD stat implementations
- Namespace parsed CLI flags and harden run_hmc against shell metacharacters
- Add tests for flag isolation and HMC command sanitization

## Testing
- `make lint` *(fails: shellcheck: command not found)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.99 8080])* 
- `make test` *(fails: bats: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ffd7a700832380db429190c89667

## Summary by Sourcery

Improve helper script portability and security by enhancing environment loading, flag parsing, and HMC command sanitization, and update related scripts to use the new flag namespace.

Enhancements:
- Make load_env detect permissions via GNU and BSD stat options with a fallback error.
- Namespace CLI flags under FLAG_ and clear existing FLAG_ variables to prevent collisions.
- Harden run_hmc and run_hmc_vios against shell metacharacter injection by validating each argument.
- Update helper scripts to source and assign FLAG_ variables instead of bare variable names.

Tests:
- Add bats tests for parse_flags isolation and run_hmc metacharacter sanitization.