### PR TITLE
Allow variable references in run_hmc command guard

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -157,7 +157,7 @@ run_hmc() {
   local hmc_cmd=("$@")
   for arg in "${hmc_cmd[@]}"; do
     [[ "${arg}" != *$'\n'* && "${arg}" != *$'\r'* ]] || die "Refusing unsafe command"
-    [[ "${arg}" != *\`* && "${arg}" != *'|'* && "${arg}" != *'&'* && "${arg}" != *'>'* && "${arg}" != *'<'* && "${arg}" != *'$'* && "${arg}" != *';'* ]] || die "Refusing unsafe command"
+    [[ "${arg}" != *\`* && "${arg}" != *'|'* && "${arg}" != *'&'* && "${arg}" != *'>'* && "${arg}" != *'<'* && "${arg}" != *'$('* && "${arg}" != *';'* ]] || die "Refusing unsafe command"
   done
   local ssh_cmd=(ssh -i "${HMC_SSH_KEY}" "${DEFAULT_SSH_OPTS[@]}" "${HMC_USER}@${HMC_HOST}" -- "${hmc_cmd[@]}")
   if [[ "${DRY_RUN}" == "1" || "${APPLY}" != "1" ]]; then


### PR DESCRIPTION
## Summary
- permit `$VAR` in run_hmc arguments while still rejecting command substitution

## Testing
- `pre-commit run --files lib/common.sh` *(fails: command not found; pip install pre-commit blocked by proxy)*
- `make test` *(fails: bats: command not found; apt-get install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a1033aed788323a36388e540a97d20