### PR TITLE
feat: add planning and host bootstrap skeleton

### DIFF
--- a/lib/parse.sh
+++ b/lib/parse.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# lib/parse.sh - YAML parsing helpers using Python (PyYAML)
+# Ensures locale-independent parsing and simple key lookup.
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+
+# yaml_get <file> <key.path>
+yaml_get() {
+  require_cmd python3
+  local file="$1" key="$2"
+  python3 - "$file" "$key" <<'PY'
+import sys, yaml, json
+file, key = sys.argv[1], sys.argv[2]
+with open(file) as f:
+    data = yaml.safe_load(f)
+val = data
+for part in key.split('.'):
+    if isinstance(val, dict):
+        val = val.get(part)
+    else:
+        val = None
+        break
+if val is None:
+    sys.exit(1)
+if isinstance(val, (dict, list)):
+    print(json.dumps(val))
+else:
+    print(val)
+PY
+}

--- a/lib/plan.sh
+++ b/lib/plan.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# lib/plan.sh - simple planning and apply helpers
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+# shellcheck source=./common.sh
+
+PLAN_PATH=""
+
+plan_init() {
+  require_cmd uuidgen
+  local run_dir="${STATE_DIR}/run"
+  local id
+  id="$(uuidgen)"
+  PLAN_PATH="${run_dir}/${id}/plan.jsonl"
+  mkdir -p "${run_dir}/${id}"
+  : >"${PLAN_PATH}"
+  echo "${PLAN_PATH}"
+}
+
+plan_add() {
+  local json="$1"
+  [[ -n "${PLAN_PATH}" ]] || die "plan_init not called"
+  printf '%s\n' "${json}" >>"${PLAN_PATH}"
+}
+
+plan_show() {
+  [[ -n "${PLAN_PATH}" ]] || die "plan_init not called"
+  cat "${PLAN_PATH}"
+}
+
+plan_apply() {
+  [[ -n "${PLAN_PATH}" ]] || die "plan_init not called"
+  require_cmd jq
+  while IFS= read -r line; do
+    local action
+    action="$(printf '%s' "$line" | jq -r '.action')"
+    case "$action" in
+      pin-hostkey)
+        local host
+        host="$(printf '%s' "$line" | jq -r '.host')"
+        pin_hostkey "$host"
+        ;;
+      *)
+        log WARN "Unknown action in plan: $action"
+        ;;
+    esac
+  done <"${PLAN_PATH}"
+}

--- a/lib/ssh.sh
+++ b/lib/ssh.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# lib/ssh.sh - thin wrapper around ssh enforcing default options
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+# shellcheck source=./common.sh
+
+ssh_safe() {
+  require_cmd ssh
+  local host="$1"
+  shift
+  pin_hostkey "$host"
+  local ssh_opts=("${DEFAULT_SSH_OPTS[@]}")
+  ssh "${ssh_opts[@]}" "$host" "$@"
+}

--- a/schema/maps.schema.yaml
+++ b/schema/maps.schema.yaml
@@ -1,0 +1,10 @@
+type: object
+required:
+  - hmc
+properties:
+  hmc:
+    type: object
+    required: [host]
+    properties:
+      host:
+        type: string

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/apply.sh - apply a previously generated plan
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+# shellcheck source=../lib/plan.sh
+. "${SCRIPT_DIR%/scripts}/lib/plan.sh"
+
+usage() { echo "Usage: $0 <plan.jsonl>"; }
+
+main() {
+  [ "$#" -eq 1 ] || { usage; exit 1; }
+  PLAN_PATH="$1"
+  [ -f "$PLAN_PATH" ] || die "plan not found: $PLAN_PATH"
+  confirm_apply
+  plan_apply
+}
+
+main "$@"

--- a/scripts/bootstrap_known_hosts.sh
+++ b/scripts/bootstrap_known_hosts.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# scripts/bootstrap_known_hosts.sh - populate known_hosts from map files
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+# shellcheck source=../lib/parse.sh
+. "${SCRIPT_DIR%/scripts}/lib/parse.sh"
+
+usage() { echo "Usage: $0 [maps/*.yaml]"; }
+
+main() {
+  [ "$#" -gt 0 ] || set -- maps/*.yaml
+  for file in "$@"; do
+    [ -f "$file" ] || continue
+    if host="$(yaml_get "$file" hmc.host 2>/dev/null)"; then
+      log INFO "pinning hostkey for $host"
+      pin_hostkey "$host"
+    else
+      log WARN "missing hmc.host in $file"
+    fi
+  done
+}
+
+main "$@"

--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# scripts/plan.sh - generate plan from map files
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+# shellcheck source=../lib/parse.sh
+. "${SCRIPT_DIR%/scripts}/lib/parse.sh"
+# shellcheck source=../lib/plan.sh
+. "${SCRIPT_DIR%/scripts}/lib/plan.sh"
+
+usage() { echo "Usage: $0 <map.yaml>"; }
+
+main() {
+  [ "$#" -eq 1 ] || { usage; exit 1; }
+  local file="$1"
+  plan_init
+  if host="$(yaml_get "$file" hmc.host 2>/dev/null)"; then
+    plan_add "{\"action\":\"pin-hostkey\",\"host\":\"$host\"}"
+    log INFO "plan stored at $PLAN_PATH"
+    echo "$PLAN_PATH"
+  else
+    die "missing hmc.host in $file"
+  fi
+}
+
+main "$@"

--- a/scripts/read_secrets.sh
+++ b/scripts/read_secrets.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/read_secrets.sh - load secrets from .env securely
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+
+usage() { echo "Usage: $0 [env-file]"; }
+
+main() {
+  local env_file="${1:-.env}"
+  load_env "$env_file"
+  echo "HMC_HOST=$HMC_HOST"
+  echo "HMC_USER=$HMC_USER"
+  echo "HMC_SSH_KEY=$HMC_SSH_KEY"
+}
+
+main "$@"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# scripts/rollback.sh - placeholder rollback handler
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+
+usage() { echo "Usage: $0 <plan.jsonl>"; }
+
+main() {
+  [ "$#" -eq 1 ] || { usage; exit 1; }
+  local plan="$1"
+  [ -f "$plan" ] || die "plan not found: $plan"
+  log INFO "rollback not implemented yet for $plan"
+}
+
+main "$@"

--- a/scripts/validate_maps.sh
+++ b/scripts/validate_maps.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# scripts/validate_maps.sh - ensure map files meet minimal schema
+set -euo pipefail
+IFS=$'\n\t'
+LC_ALL=C
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+# shellcheck source=../lib/parse.sh
+. "${SCRIPT_DIR%/scripts}/lib/parse.sh"
+
+usage() { echo "Usage: $0 [maps/*.yaml]"; }
+
+main() {
+  [ "$#" -gt 0 ] || set -- maps/*.yaml
+  local ok=1
+  for file in "$@"; do
+    [ -f "$file" ] || continue
+    if yaml_get "$file" hmc.host >/dev/null 2>&1; then
+      log INFO "validated $file"
+    else
+      log ERROR "$file missing hmc.host"
+      ok=0
+    fi
+  done
+  return $ok
+}
+
+main "$@"

--- a/tests/fixtures/map.yaml
+++ b/tests/fixtures/map.yaml
@@ -1,0 +1,2 @@
+hmc:
+  host: test-hmc.example.com

--- a/tests/integration/plan_apply.bats
+++ b/tests/integration/plan_apply.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+@test "plan and apply pin-hostkey" {
+  run bash -lc 'PATH=tests/stubs:$PATH; plan=$(./scripts/plan.sh tests/fixtures/map.yaml); ./scripts/apply.sh "$plan"'
+  [ "$status" -eq 0 ]
+}

--- a/tests/stubs/ssh-keyscan
+++ b/tests/stubs/ssh-keyscan
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Stub ssh-keyscan for tests
+while getopts 'H:T:' opt; do :; done
+shift $((OPTIND-1))
+host=$1
+echo "$host ssh-rsa AAAAFakeKey"

--- a/tests/unit/parse.bats
+++ b/tests/unit/parse.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+@test "yaml_get returns value" {
+  run bash -lc '. ./lib/parse.sh; yaml_get tests/fixtures/map.yaml hmc.host'
+  [ "$status" -eq 0 ]
+  [ "$output" = "test-hmc.example.com" ]
+}

--- a/tests/unit/plan.bats
+++ b/tests/unit/plan.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+@test "plan_init creates file" {
+  run bash -lc '. ./lib/common.sh; . ./lib/plan.sh; plan_init; [ -f "$PLAN_PATH" ] && echo ok'
+  [ "$status" -eq 0 ]
+  [ "$output" = ok ]
+}
+
+@test "plan_add appends line" {
+  run bash -lc '. ./lib/common.sh; . ./lib/plan.sh; plan_init; plan_add "{\"action\":\"pin-hostkey\",\"host\":\"h\"}"; wc -l < "$PLAN_PATH"'
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- add YAML parsing helpers and basic plan storage
- bootstrap known_hosts from maps and apply plan actions
- add initial schema and Bats tests for planning utilities

## Testing
- `shellcheck lib/parse.sh lib/ssh.sh lib/plan.sh scripts/bootstrap_known_hosts.sh scripts/read_secrets.sh scripts/validate_maps.sh scripts/plan.sh scripts/apply.sh scripts/rollback.sh` *(fails: command not found)*
- `shfmt -d -i 2 -ci -sr scripts/bootstrap_known_hosts.sh` *(fails: command not found)*
- `bats -r tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22033e6888323a02260bf814848d4