### PR TITLE
refactor plan and parse utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ usage details.
 - Idempotency markers in `${TMPDIR:-/var/tmp}/vios-autoconfig-*` prevent repeated work
   unless `--force` is supplied.
 - Logging uses INFO/WARN/ERROR levels and masks credentials.
+- Scripts source a central `lib/header.sh` which applies shell safety flags and logging setup.
+- `yaml_get` returns exit code **3** when a key is missing (distinct from parse/runtime errors).
+- `plan_apply` now exits non-zero on unknown actions; malformed JSON lines are logged and skipped.
 
 ## Testing
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -2,8 +2,6 @@
 # lib/common.sh - shared safety, logging, and HMC helpers
 # Follows Google Shell Style Guide & OWASP shell safety guidance.
 
-set -euo pipefail
-IFS=$'\n\t'
 umask 077
 
 # ---- Globals (readonly)

--- a/lib/header.sh
+++ b/lib/header.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Centralized header for all scripts: sets safe shell options and sources common helpers.
+set -Eeuo pipefail
+IFS=$' \t\n'
+LC_ALL=C
+umask 077
+
+# Resolve library directory and source common.sh
+_hdr_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+. "${_hdr_dir}/common.sh"

--- a/lib/parse.sh
+++ b/lib/parse.sh
@@ -1,19 +1,31 @@
 #!/usr/bin/env bash
 # lib/parse.sh - YAML parsing helpers using Python (PyYAML)
-# Ensures locale-independent parsing and simple key lookup.
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
+. "$(dirname "${BASH_SOURCE[0]}")/header.sh"
 
 # yaml_get <file> <key.path>
 yaml_get() {
   require_cmd python3
   local file="$1" key="$2"
   python3 - "$file" "$key" <<'PY'
-import sys, yaml, json
-file, key = sys.argv[1], sys.argv[2]
-with open(file) as f:
-    data = yaml.safe_load(f)
+import sys, json
+try:
+    import yaml
+except Exception:
+    sys.exit(2)  # parse error / missing dependency
+
+MISSING_KEY_EXIT = 3
+RUNTIME_ERR_EXIT = 1
+PARSE_ERR_EXIT = 2
+
+try:
+    file, key = sys.argv[1], sys.argv[2]
+    with open(file) as f:
+        data = yaml.safe_load(f)
+except yaml.YAMLError:
+    sys.exit(PARSE_ERR_EXIT)
+except Exception:
+    sys.exit(RUNTIME_ERR_EXIT)
+
 val = data
 for part in key.split('.'):
     if isinstance(val, dict):
@@ -22,7 +34,7 @@ for part in key.split('.'):
         val = None
         break
 if val is None:
-    sys.exit(1)
+    sys.exit(MISSING_KEY_EXIT)
 if isinstance(val, (dict, list)):
     print(json.dumps(val))
 else:

--- a/lib/plan.sh
+++ b/lib/plan.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 # lib/plan.sh - simple planning and apply helpers
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
-# shellcheck source=./common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/header.sh"
 
 PLAN_PATH=""
 
@@ -18,10 +15,26 @@ plan_init() {
   echo "${PLAN_PATH}"
 }
 
+# Validate action JSON line; returns 0 if schema ok
+plan_validate() {
+  require_cmd jq
+  local line="$1"
+  printf '%s' "$line" | jq -e 'type=="object" and (.action|type=="string" and length>0)' >/dev/null
+}
+
 plan_add() {
   local json="$1"
   [[ -n "${PLAN_PATH}" ]] || die "plan_init not called"
-  printf '%s\n' "${json}" >>"${PLAN_PATH}"
+  require_cmd jq
+  if ! printf '%s' "$json" | jq -e . >/dev/null 2>&1; then
+    log ERROR "plan_add: invalid JSON"
+    return 1
+  fi
+  if ! plan_validate "$json"; then
+    log ERROR "plan_add: JSON missing required fields"
+    return 1
+  fi
+  printf '%s\n' "$json" >>"${PLAN_PATH}"
 }
 
 plan_show() {
@@ -32,18 +45,35 @@ plan_show() {
 plan_apply() {
   [[ -n "${PLAN_PATH}" ]] || die "plan_init not called"
   require_cmd jq
+  local status=0
   while IFS= read -r line; do
+    [[ -n "${line//[[:space:]]/}" ]] || continue
+    if ! printf '%s' "$line" | jq -e . >/dev/null 2>&1; then
+      log WARN "plan_apply: skipping malformed JSON line: $line"
+      continue
+    fi
+    if ! plan_validate "$line"; then
+      log WARN "plan_apply: skipping invalid action schema: $line"
+      continue
+    fi
     local action
     action="$(printf '%s' "$line" | jq -r '.action')"
     case "$action" in
       pin-hostkey)
         local host
         host="$(printf '%s' "$line" | jq -r '.host')"
+        if [[ -z "$host" || "$host" == "null" ]]; then
+          log ERROR "pin-hostkey missing host"
+          status=1
+          continue
+        fi
         pin_hostkey "$host"
         ;;
       *)
-        log WARN "Unknown action in plan: $action"
+        log ERROR "unknown action in plan: $action"
+        return 1
         ;;
     esac
   done <"${PLAN_PATH}"
+  return "$status"
 }

--- a/lib/ssh.sh
+++ b/lib/ssh.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 # lib/ssh.sh - thin wrapper around ssh enforcing default options
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
-# shellcheck source=./common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/header.sh"
 
 ssh_safe() {
   require_cmd ssh

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 # scripts/apply.sh - apply a previously generated plan
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
-# shellcheck source=../lib/plan.sh
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 . "${SCRIPT_DIR%/scripts}/lib/plan.sh"
 
 usage() { echo "Usage: $0 <plan.jsonl>"; }

--- a/scripts/bootstrap_known_hosts.sh
+++ b/scripts/bootstrap_known_hosts.sh
@@ -1,27 +1,38 @@
 #!/usr/bin/env bash
 # scripts/bootstrap_known_hosts.sh - populate known_hosts from map files
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
-# shellcheck source=../lib/parse.sh
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 . "${SCRIPT_DIR%/scripts}/lib/parse.sh"
 
 usage() { echo "Usage: $0 [maps/*.yaml]"; }
 
 main() {
   [ "$#" -gt 0 ] || set -- maps/*.yaml
+  local -a hosts=()
+  local file host
   for file in "$@"; do
     [ -f "$file" ] || continue
     if host="$(yaml_get "$file" hmc.host 2>/dev/null)"; then
-      log INFO "pinning hostkey for $host"
-      pin_hostkey "$host"
+      hosts+=("$host")
     else
       log WARN "missing hmc.host in $file"
     fi
   done
+
+  if [ "${#hosts[@]}" -gt 0 ]; then
+    declare -A seen=()
+    local -a unique_hosts=()
+    for host in "${hosts[@]}"; do
+      if [[ -z "${seen[$host]:-}" ]]; then
+        unique_hosts+=("$host")
+        seen[$host]=1
+      fi
+    done
+    for host in "${unique_hosts[@]}"; do
+      log INFO "pinning hostkey for $host"
+      pin_hostkey "$host"
+    done
+  fi
 }
 
 main "$@"

--- a/scripts/create_npiv.sh
+++ b/scripts/create_npiv.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 # scripts/create_npiv.sh - create NPIV mapping between VIOS and LPAR
-set -euo pipefail
-IFS=$'\n\t'
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 
 usage() {
   cat <<EOF

--- a/scripts/create_sea.sh
+++ b/scripts/create_sea.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 # scripts/create_sea.sh - create Shared Ethernet Adapter on a VIOS
-set -euo pipefail
-IFS=$'\n\t'
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 
 usage() {
   cat <<EOF

--- a/scripts/create_vscsi.sh
+++ b/scripts/create_vscsi.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 # scripts/create_vscsi.sh - create vSCSI mapping for an LPAR via HMC/VIOS
-set -euo pipefail
-IFS=$'\n\t'
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 
 usage() {
   cat <<EOF

--- a/scripts/map_scsi.sh
+++ b/scripts/map_scsi.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 # scripts/map_scsi.sh - map an hdisk to an LPAR via vhost
-set -euo pipefail
-IFS=$'\n\t'
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 
 usage() {
   cat <<EOF

--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
 # scripts/plan.sh - generate plan from map files
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
-# shellcheck source=../lib/parse.sh
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 . "${SCRIPT_DIR%/scripts}/lib/parse.sh"
-# shellcheck source=../lib/plan.sh
 . "${SCRIPT_DIR%/scripts}/lib/plan.sh"
 
 usage() { echo "Usage: $0 <map.yaml>"; }

--- a/scripts/read_secrets.sh
+++ b/scripts/read_secrets.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 # scripts/read_secrets.sh - load secrets from .env securely
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 
 usage() { echo "Usage: $0 [env-file]"; }
 

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 # scripts/rollback.sh - placeholder rollback handler
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 
 usage() { echo "Usage: $0 <plan.jsonl>"; }
 

--- a/scripts/validate_maps.sh
+++ b/scripts/validate_maps.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 # scripts/validate_maps.sh - ensure map files meet minimal schema
-set -euo pipefail
-IFS=$'\n\t'
-LC_ALL=C
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
-# shellcheck source=../lib/parse.sh
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 . "${SCRIPT_DIR%/scripts}/lib/parse.sh"
 
 usage() { echo "Usage: $0 [maps/*.yaml]"; }

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 # scripts/verify.sh - display VIOS mappings
-set -euo pipefail
-IFS=$'\n\t'
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../lib/common.sh
-. "${SCRIPT_DIR%/scripts}/lib/common.sh"
+. "${SCRIPT_DIR%/scripts}/lib/header.sh"
 
 usage() {
   cat <<EOF

--- a/tests/unit/parse.bats
+++ b/tests/unit/parse.bats
@@ -8,3 +8,8 @@ load '../test_helper/bats-assert/load'
   [ "$status" -eq 0 ]
   [ "$output" = "test-hmc.example.com" ]
 }
+
+@test "yaml_get returns exit code 3 when key missing" {
+  run bash -lc '. ./lib/parse.sh; yaml_get tests/fixtures/map.yaml does.not.exist'
+  [ "$status" -eq 3 ]
+}

--- a/tests/unit/plan.bats
+++ b/tests/unit/plan.bats
@@ -4,13 +4,51 @@ load '../test_helper/bats-support/load'
 load '../test_helper/bats-assert/load'
 
 @test "plan_init creates file" {
-  run bash -lc '. ./lib/common.sh; . ./lib/plan.sh; plan_init; [ -f "$PLAN_PATH" ] && echo ok'
+  run bash -lc '. ./lib/plan.sh; plan_init; [ -f "$PLAN_PATH" ] && echo ok'
   [ "$status" -eq 0 ]
   [ "$output" = ok ]
 }
 
 @test "plan_add appends line" {
-  run bash -lc '. ./lib/common.sh; . ./lib/plan.sh; plan_init; plan_add "{\"action\":\"pin-hostkey\",\"host\":\"h\"}"; wc -l < "$PLAN_PATH"'
+  run bash -lc '. ./lib/plan.sh; plan_init; plan_add "{\"action\":\"pin-hostkey\",\"host\":\"h\"}"; wc -l < "$PLAN_PATH"'
   [ "$status" -eq 0 ]
   [ "$output" -eq 1 ]
+}
+
+@test "plan_add appends multiple lines" {
+  run bash -lc '
+    . ./lib/plan.sh;
+    plan_init;
+    plan_add "{\"action\":\"pin-hostkey\",\"host\":\"h1\"}";
+    plan_add "{\"action\":\"pin-hostkey\",\"host\":\"h2\"}";
+    plan_add "{\"action\":\"pin-hostkey\",\"host\":\"h3\"}";
+    wc -l < "$PLAN_PATH"
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 3 ]
+}
+
+@test "plan_apply skips malformed JSON but processes valid entries" {
+  run bash -lc '
+    . ./lib/plan.sh;
+    plan_init;
+    plan_add "{\"action\":\"pin-hostkey\",\"host\":\"good.example\"}";
+    echo "{this is: not json" >> "$PLAN_PATH";
+    plan_add "{\"action\":\"pin-hostkey\",\"host\":\"good2.example\"}";
+    pin_hostkey(){ echo "PIN:$1"; }
+    export -f pin_hostkey
+    plan_apply 2>&1 | grep "^PIN"
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = $'PIN:good.example\nPIN:good2.example' ]
+}
+
+@test "plan_apply fails fast on unknown action" {
+  run bash -lc '
+    . ./lib/plan.sh;
+    plan_init;
+    echo "{\"action\":\"totally-unknown\"}" >> "$PLAN_PATH";
+    plan_apply
+  '
+  [ "$status" -ne 0 ]
 }

--- a/vios-auto.sh
+++ b/vios-auto.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
 SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
-. "$SCRIPT_DIR/lib/common.sh"
+. "$SCRIPT_DIR/lib/header.sh"
 
 usage() {
 cat <<USAGE


### PR DESCRIPTION
## Summary
- add central `lib/header.sh` for safe Bash defaults and source it across scripts
- validate JSON actions and fail on unknown operations in plan handling
- return distinct exit codes from `yaml_get` and deduplicate host pinning
- document behavioral changes and extend unit tests

## Testing
- ⚠️ `bats tests/unit` *(missing `bats`; apt repository access denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a223857e5c8323a63e4daf454aecf7