### PR TITLE
fix: improve yaml_get and plan_apply error handling

### DIFF
--- a/lib/plan.sh
+++ b/lib/plan.sh
@@ -62,7 +62,7 @@ plan_apply() {
       pin-hostkey)
         local host
         host="$(printf '%s' "$line" | jq -r '.host')"
-        if [[ -z "$host" ]]; then
+        if [[ -z "$host" || "$host" == "null" ]]; then
           log ERROR "pin-hostkey missing host"
           status=1
           continue
@@ -72,9 +72,10 @@ plan_apply() {
       *)
         log ERROR "Unknown action: $action"
         status=1
+        # Continue processing to report all unknown actions
         continue
         ;;
     esac
   done <"${PLAN_PATH}"
-  return "$status"
+  return $status
 }

--- a/tests/fixtures/map.yaml
+++ b/tests/fixtures/map.yaml
@@ -1,2 +1,3 @@
 hmc:
   host: test-hmc.example.com
+"with.dot": dot-value

--- a/tests/unit/parse.bats
+++ b/tests/unit/parse.bats
@@ -14,3 +14,9 @@ load '../test_helper/bats-assert/load'
   run bash -lc '. ./lib/parse.sh; yaml_get tests/fixtures/map.yaml does.not.exist'
   [ "$status" -eq "$missing_code" ]
 }
+
+@test "yaml_get handles keys with dots" {
+  run bash -lc '. ./lib/parse.sh; yaml_get tests/fixtures/map.yaml with\\.dot'
+  [ "$status" -eq 0 ]
+  [ "$output" = "dot-value" ]
+}

--- a/tests/unit/plan.bats
+++ b/tests/unit/plan.bats
@@ -53,3 +53,14 @@ load '../test_helper/bats-assert/load'
   [ "$status" -ne 0 ]
   [[ "$output" == *"Unknown action: totally-unknown"* ]]
 }
+
+@test "plan_apply rejects host value null" {
+  run bash -lc '
+    . ./lib/plan.sh;
+    plan_init;
+    echo "{\"action\":\"pin-hostkey\",\"host\":null}" >> "$PLAN_PATH";
+    plan_apply
+  '
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pin-hostkey missing host"* ]]
+}


### PR DESCRIPTION
## Summary
- pass yaml_get error codes as CLI arguments and allow escaping dots in keys
- validate pin-hostkey host for empty or "null" values and continue after unknown actions
- add tests for dotted YAML keys and null host values

## Testing
- `make lint` *(fails: shellcheck: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `make test` *(fails: bats: command not found)*
- `git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68a22983deec8323bb189598f425fb93

## Summary by Sourcery

Improve error handling in yaml_get and plan_apply by passing error codes as CLI arguments, supporting escaped dots in YAML keys, validating null host values, and continuing after unknown actions

Bug Fixes:
- Treat literal "null" host as missing in pin-hostkey action
- Reject null or empty host values in plan_apply

Enhancements:
- Pass yaml_get error codes as command-line arguments
- Add support for escaping dots in YAML keys for yaml_get
- Continue processing remaining actions after unknown actions in plan_apply

Tests:
- Add test for yaml_get with escaped dot keys
- Add test for rejecting null host values in plan_apply

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - YAML key lookup now supports escaped dots in key paths (e.g., use with\.dot to access keys containing periods).

- Bug Fixes
  - Stricter validation for pin-hostkey: empty or “null” host values are rejected with clear errors.
  - More consistent error handling and messages when reading or parsing YAML and when keys are missing.

- Documentation
  - Documented how to escape dots in YAML keys during lookup.

- Tests
  - Added tests for escaped-dot key lookup and for rejecting null/empty host values in pin-hostkey.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->