### PR TITLE
Refactor YAML key parsing and add edge case tests

### DIFF
--- a/lib/parse.sh
+++ b/lib/parse.sh
@@ -28,19 +28,26 @@ except Exception:
     sys.exit(runtime_err)
 
 # Split key on unescaped dots; "\." denotes a literal dot in the key
-parts, buf, esc = [], "", False
-for ch in key:
+def split_key(path):
+    """Split a dotted key into components, honoring backslash escapes."""
+    parts, buf, esc = [], "", False
+    for ch in path:
+        if esc:
+            buf += ch
+            esc = False
+        elif ch == "\\":
+            esc = True
+        elif ch == ".":
+            parts.append(buf)
+            buf = ""
+        else:
+            buf += ch
     if esc:
-        buf += ch
-        esc = False
-    elif ch == "\\":
-        esc = True
-    elif ch == ".":
-        parts.append(buf)
-        buf = ""
-    else:
-        buf += ch
-parts.append(buf)
+        buf += "\\"
+    parts.append(buf)
+    return parts
+
+parts = split_key(key)
 
 val = data
 for part in parts:

--- a/lib/plan.sh
+++ b/lib/plan.sh
@@ -61,8 +61,8 @@ plan_apply() {
     case "$action" in
       pin-hostkey)
         local host
-        host="$(printf '%s' "$line" | jq -r '.host')"
-        if [[ -z "$host" || "$host" == "null" ]]; then
+        host="$(printf '%s' "$line" | jq -r '.host // empty')"
+        if [[ -z "$host" ]]; then
           log ERROR "pin-hostkey missing host"
           status=1
           continue

--- a/tests/fixtures/map.yaml
+++ b/tests/fixtures/map.yaml
@@ -1,3 +1,5 @@
 hmc:
   host: test-hmc.example.com
 "with.dot": dot-value
+"with..dots": double-dot-value
+"with\\backslash": backslash-value

--- a/tests/unit/parse.bats
+++ b/tests/unit/parse.bats
@@ -20,3 +20,15 @@ load '../test_helper/bats-assert/load'
   [ "$status" -eq 0 ]
   [ "$output" = "dot-value" ]
 }
+
+@test "yaml_get handles consecutive escaped dots" {
+  run bash -lc '. ./lib/parse.sh; yaml_get tests/fixtures/map.yaml with\\.\\.dots'
+  [ "$status" -eq 0 ]
+  [ "$output" = "double-dot-value" ]
+}
+
+@test "yaml_get handles literal backslashes" {
+  run bash -lc '. ./lib/parse.sh; yaml_get tests/fixtures/map.yaml with\\\\backslash'
+  [ "$status" -eq 0 ]
+  [ "$output" = "backslash-value" ]
+}


### PR DESCRIPTION
## Summary
- extract key-splitting logic in `yaml_get` into a helper
- add yaml_get tests for consecutive escaped dots and literal backslashes
- simplify `pin-hostkey` host check

## Testing
- `make lint` *(fails: shellcheck: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `make test` *(fails: bats: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22b1efca483239858485633019f7b

## Summary by Sourcery

Refactor YAML key parsing into a dedicated helper, add tests covering escaped dots and backslashes in yaml_get, and streamline host validation in the pin-hostkey plan

Enhancements:
- Refactor YAML key parsing into a split_key helper function
- Simplify pin-hostkey action host extraction logic

Tests:
- Add yaml_get tests for consecutive escaped dots
- Add yaml_get tests for literal backslashes