### PR TITLE
Validate HMC credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Use `make fmt-write` to apply formatting. CI executes `make lint test` on pushes
 - **Strict mode**: All scripts use `set -euo pipefail` and safe `IFS`.
 - **Dry-run vs Apply**: Set `DRY_RUN=1` (default) to preview; set `APPLY=1` to execute. Non-CI runs prompt for confirmation.
 - **HMC credentials**: Provide `HMC_HOST`, `HMC_USER`, `HMC_SSH_KEY` in `.env` (chmod 600). SSH key auth only.
+- **Input validation**: `HMC_HOST` and `HMC_USER` accept only alphanumeric, dot,
+  underscore, dash, and (for host) colon characters.
 - **Host key pinning**: First run captures and pins `${HMC_HOST}` key into `/var/tmp/vios-autoconfig/known_hosts` and enables `StrictHostKeyChecking=yes`.
 - **Logging**: Logs in `/var/tmp/vios-autoconfig/logs/` with basic redaction of sensitive tokens.
 - **CI**: GitHub Actions run ShellCheck, shfmt, Bats, Gitleaks, and actionlint on PRs/pushes.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -56,6 +56,8 @@ load_env() {
   : "${HMC_HOST:?HMC_HOST is required}"
   : "${HMC_USER:?HMC_USER is required}"
   : "${HMC_SSH_KEY:?HMC_SSH_KEY is required}"
+  [[ "${HMC_HOST}" =~ ^[A-Za-z0-9._:-]+$ ]] || die "Invalid HMC_HOST: ${HMC_HOST}"
+  [[ "${HMC_USER}" =~ ^[A-Za-z0-9._-]+$ ]] || die "Invalid HMC_USER: ${HMC_USER}"
   [[ -f "${HMC_SSH_KEY}" ]] || die "HMC_SSH_KEY not found: ${HMC_SSH_KEY}"
   if ! chmod 600 "${HMC_SSH_KEY}" 2>/dev/null; then
     log WARN "Failed to set permissions on HMC_SSH_KEY: ${HMC_SSH_KEY}"


### PR DESCRIPTION
## Summary
- restrict `HMC_HOST` and `HMC_USER` to safe character sets during environment loading
- document credential input validation in security section

## Testing
- `make lint` *(fails: shellcheck: command not found)*
- `make test` *(fails: bats: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec0121908323938aca7aa9ad718a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added strict validation for HMC_HOST and HMC_USER. Nonconforming values now fail fast with clear error messages to prevent misconfiguration. Allowed characters: alphanumeric plus dot, underscore, dash; HMC_HOST also allows colon.

* **Documentation**
  * Clarified the accepted character sets for HMC_HOST and HMC_USER to match the new validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->